### PR TITLE
perf: use native api insted of user-home

### DIFF
--- a/packages/svrx-util/lib/rc-file-read.js
+++ b/packages/svrx-util/lib/rc-file-read.js
@@ -1,5 +1,5 @@
 const cosmiconfig = require('cosmiconfig');
-const userHome = require('user-home');
+const userHome = require('os').homedir();
 const path = require('path');
 const fs = require('fs');
 

--- a/packages/svrx-util/npm-shrinkwrap.json
+++ b/packages/svrx-util/npm-shrinkwrap.json
@@ -5694,14 +5694,6 @@
         "has-flag": "3.0.0"
       }
     },
-    "user-home": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "requires": {
-        "os-homedir": "1.0.2"
-      }
-    },
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",

--- a/packages/svrx-util/package.json
+++ b/packages/svrx-util/package.json
@@ -33,8 +33,7 @@
     "npm": "^6.9.0",
     "npmi": "^2.0.1",
     "ora": "^3.4.0",
-    "rimraf": "^2.6.3",
-    "user-home": "^2.0.0"
+    "rimraf": "^2.6.3"
   },
   "devDependencies": {
     "expect.js": "^0.3.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines         
- [ ] Tests for the changes have been added (for bug fixes / features)          
- [ ] Docs have been added / updated (for bug fixes / features)                      

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

[user-home](https://github.com/sindresorhus/user-home) is based on [os-homedir](https://github.com/sindresorhus/os-homedir) which was deprecated

* **What is the related issue?** (Use `#issue_id` to relate an open issue)



* **Does this PR introduce a breaking change?** 



* **Other information**:
