### PR TITLE
Replace global-npm.install with npminstall

### DIFF
--- a/packages/svrx-util/__tests__/spec/npm.test.js
+++ b/packages/svrx-util/__tests__/spec/npm.test.js
@@ -30,8 +30,27 @@ describe('npm', () => {
     }).then((result) => {
       expect(result.version).to.equal('3.0.0');
       const expectModulePath = libPath.join(MODULE_PATH, '/node_modules/lodash.noop');
+      const expectModuleRealPath = libPath.join(MODULE_PATH, '/node_modules/_lodash.noop@3.0.0@lodash.noop');
       expect(result.path).to.equal(expectModulePath);
       expect(libFs.statSync(expectModulePath).isDirectory()).to.equal(true);
+      expect(libFs.existsSync(expectModuleRealPath)).to.equal(true);
+      done();
+    });
+  }).timeout(10000);
+
+  it('CLI: global install', (done) => {
+    npm.install({
+      global: true,
+      path: MODULE_PATH,
+      name: 'lodash.noop',
+      version: '3.0.0',
+    }).then((result) => {
+      expect(result.version).to.equal('3.0.0');
+      const expectModulePath = libPath.join(MODULE_PATH, '/node_modules/lodash.noop');
+      const expectModuleRealPath = libPath.join(MODULE_PATH, '/node_modules/_lodash.noop@3.0.0@lodash.noop');
+      expect(result.path).to.equal(expectModulePath);
+      expect(libFs.statSync(expectModulePath).isDirectory()).to.equal(true);
+      expect(libFs.existsSync(expectModuleRealPath)).to.equal(false);
       done();
     });
   }).timeout(10000);
@@ -51,6 +70,7 @@ describe('npm', () => {
       done();
     });
   }).timeout(10000);
+
   it('npm view version', (done) => {
     npm.view(['svrx-plugin-demo@*', 'engines']).then((ret) => {
       Object.keys(ret).forEach((i) => {

--- a/packages/svrx-util/__tests__/spec/readJSON.test.js
+++ b/packages/svrx-util/__tests__/spec/readJSON.test.js
@@ -1,0 +1,23 @@
+const libPath = require('path');
+const expect = require('expect.js');
+const readJSON = require('../../lib/readJSON');
+
+const TEST_PLUGIN_PATH = libPath.join(__dirname, '../fixture/plugin/svrx-plugin-test');
+
+describe('readJSON', () => {
+  it('read a json file', () => {
+    const json = readJSON(libPath.join(TEST_PLUGIN_PATH, 'package.json'));
+    expect(json.version).to.eql('0.0.1');
+  });
+  it('read a non-exist file', () => {
+    const json = readJSON(libPath.join(TEST_PLUGIN_PATH, 'non-exist.json'));
+    expect(json).to.eql({});
+  });
+  it('read a non-json file', () => {
+    try {
+      readJSON(libPath.join(TEST_PLUGIN_PATH, 'index.js'));
+    } catch (e) {
+      expect(e).to.match(/SyntaxError: Unexpected token/);
+    }
+  });
+});

--- a/packages/svrx-util/lib/npm/index.js
+++ b/packages/svrx-util/lib/npm/index.js
@@ -2,8 +2,10 @@ const libPath = require('path');
 const nUtil = require('util');
 const _ = require('lodash');
 const npm = require('global-npm');
+const npminstall = require('npminstall');
 const npCall = require('../npCall');
 const DevNull = require('./devnull');
+const readJSON = require('../readJSON');
 
 const SILENT_SUGAR_NOT_NECESSARILY_WORKS = {
   loglevel: 'silent',
@@ -15,7 +17,6 @@ const SILENT_SUGAR_NOT_NECESSARILY_WORKS = {
 const load = _.memoize(async (options) => nUtil.promisify(npm.load).bind(npm, {
   ...SILENT_SUGAR_NOT_NECESSARILY_WORKS,
   ...options,
-  save: false,
 })());
 
 const normalizeNpmCommand = (command) => async function callNpm(argsArr, options = {}, root) {
@@ -27,30 +28,35 @@ const normalizeNpmCommand = (command) => async function callNpm(argsArr, options
 
 const npmView = normalizeNpmCommand('view');
 const npmSearch = normalizeNpmCommand('search');
-const npmInstall = normalizeNpmCommand('install');
 
 const install = (options) => {
-  const installPath = options.path || '.';
+  const installPath = options.path || process.cwd();
 
   return new Promise((resolve, reject) => {
-    const installName = options.version ? `${options.name}@${options.version}` : options.name;
-    npmInstall([installName], {
+    // Due to some history reason:
+    // options use 'name' to specify the local install path of package,
+    // but npminstall uses 'version'
+    const name = options.localInstall ? '' : options.name;
+    const version = options.localInstall ? options.name : options.version;
+    const pkgName = options.localInstall ? options.nameReal : options.name;
+
+    npminstall({
+      root: installPath,
+      pkgs: [
+        { name, version },
+      ],
       registry: options.registry,
-      ...options.npmLoad,
-    }, installPath).then((result) => {
-      if (!result) return resolve(result);
-      const packName = (() => {
-        const { localInstall, nameReal, name } = options;
-        return localInstall ? nameReal : name;
-      })();
-      const pack = result.map((r) => {
-        const [, name, version] = /(\S+)@(\S+)/.exec(r[0]);
+      ignoreScripts: false,
+      save: false,
+    }).then(() => {
+      const pkgPath = libPath.join(installPath, 'node_modules', pkgName);
+      const pkg = readJSON(libPath.join(pkgPath, 'package.json'));
 
-        const path = !libPath.isAbsolute(r[1]) ? libPath.join(installPath, r[1]) : r[1];
-        return { version, name, path };
-      }).find((r) => r.name === packName);
-
-      return resolve(pack);
+      return resolve({
+        version: pkg.version,
+        name: pkgName,
+        path: pkgPath,
+      });
     }).catch((err) => {
       reject(err);
     });

--- a/packages/svrx-util/lib/npm/index.js
+++ b/packages/svrx-util/lib/npm/index.js
@@ -39,9 +39,11 @@ const install = (options) => {
     const name = options.localInstall ? '' : options.name;
     const version = options.localInstall ? options.name : options.version;
     const pkgName = options.localInstall ? options.nameReal : options.name;
-
-    npminstall({
+    const installMethod = options.global ? npminstall.installGlobal : npminstall;
+    installMethod({
       root: installPath,
+      // global install only
+      targetDir: options.global ? installPath : undefined,
       pkgs: [
         { name, version },
       ],

--- a/packages/svrx-util/lib/readJSON.js
+++ b/packages/svrx-util/lib/readJSON.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+
+module.exports = (filepath) => {
+  if (!fs.existsSync(filepath)) {
+    return {};
+  }
+  const content = fs.readFileSync(filepath, 'utf8');
+  try {
+    return JSON.parse(content.trim());
+  } catch (err) {
+    err.message += ` (file: ${filepath})`;
+    console.error('content buffer: %j', fs.readFileSync(filepath));
+    throw err;
+  }
+};

--- a/packages/svrx-util/lib/svrx-util.js
+++ b/packages/svrx-util/lib/svrx-util.js
@@ -1,4 +1,5 @@
 exports.rcFileRead = require('./rc-file-read');
+exports.readJSON = require('./readJSON');
 exports.logger = require('./logger');
 exports.npm = require('./npm');
 exports.c2k = require('./c2k');

--- a/packages/svrx-util/package.json
+++ b/packages/svrx-util/package.json
@@ -29,8 +29,9 @@
   "dependencies": {
     "chalk": "^2.4.2",
     "cosmiconfig": "^5.2.1",
-    "global-npm": "^0.3.0",
+    "global-npm": "^0.4.0",
     "lodash": "^4.17.11",
+    "npminstall": "^4.3.0",
     "ora": "^4.0.1",
     "rimraf": "^3.0.0"
   }


### PR DESCRIPTION
to prevent other plugin auto deletion when install a new one

<!--- Provide a general summary of your changes in the Title above -->

* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines         
- [x] Tests for the changes have been added (for bug fixes / features)          
- [ ] Docs have been added / updated (for bug fixes / features)                      

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the related issue?** (Use `#issue_id` to relate an open issue)

#142

* **Does this PR introduce a breaking change?** 

no

* **Other information**:

- Prevent the other plugins auto deletion when install a new one
- Speed up the installation