### PR TITLE
fix: revert global-npm to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.1.3 (2019-12-02)
+
+#### :bug: Bug Fix
+* `svrx-util`
+  * [#165](https://github.com/svrxjs/svrx/pull/165) Fix `Error: Cannot find module 'npm'` when starting svrx core from npm scripts ([@xuchaoying](https://github.com/xuchaoying))
+
 ## v1.1.2 (2019-12-02)
 
 ## v1.1.1 (2019-11-28)

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.1.2",
+  "version": "1.1.3",
   "npmClient": "npm",
   "changelog": {
     "repo": "svrxjs/svrx",

--- a/packages/svrx-util/package.json
+++ b/packages/svrx-util/package.json
@@ -30,7 +30,7 @@
     "chalk": "^3.0.0",
     "cosmiconfig": "^6.0.0",
     "fs-extra": "^8.1.0",
-    "global-npm": "^0.4.0",
+    "global-npm": "^0.3.0",
     "lodash": "^4.17.11",
     "mkdirp": "^0.5.1",
     "ora": "^4.0.1",

--- a/packages/svrx-util/package.json
+++ b/packages/svrx-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@svrx/util",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "util package of svrx",
   "homepage": "https://svrx.io/",
   "license": "MIT",

--- a/packages/svrx/package.json
+++ b/packages/svrx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@svrx/svrx",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "svrx server live-reload mock ",
   "keywords": [
     "svrx",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines         
- [ ] Tests is needed? <!--- Uncheck if not -->
    - [ ] Tests for the changes have been added
- [ ] Docs is needed? <!--- Uncheck if not -->
    - [ ] Docs have been added / updated               

## What kind of change does this PR introduce? 

- [x] Bug fix
- [ ] Feature
- [ ] Enhencement
- [ ] Refactor
- [ ] Documents
- [ ] Others

<!--- Summarize the changes below  -->

1. revert `global-npm` back to `0.3.0` to fix the problem that `cannot find 'npm'` when start `svrx` core from npm scripts.

## What is the related issue? 
<!--- Use `#issue_id` to relate an open issue -->



## Does this PR introduce a breaking change?

- [ ] breaking change？

<!--- If true, describe the breaking change below  -->

## Other information:
