### PR TITLE
Fix window.__svrx__ undefined when using require.js

### DIFF
--- a/packages/svrx/lib/injector/index.js
+++ b/packages/svrx/lib/injector/index.js
@@ -133,8 +133,8 @@ module.exports = class Injector {
   _transform(body) {
     const { config } = this;
     const replaceScript = [
-      '<head>',
-      `<head><script src="${config.get('urls.script')}" charset="UTF-8"></script>`,
+      '</body>',
+      `<script async src="${config.get('urls.script')}" charset="UTF-8"></script></body>`,
     ];
     const replaceStyle = [
       /<\/(head|body)>/,

--- a/packages/svrx/lib/injector/index.js
+++ b/packages/svrx/lib/injector/index.js
@@ -133,8 +133,8 @@ module.exports = class Injector {
   _transform(body) {
     const { config } = this;
     const replaceScript = [
-      '</body>',
-      `<script async src="${config.get('urls.script')}" charset="UTF-8"></script></body>`,
+      '<head>',
+      `<head><script src="${config.get('urls.script')}" charset="UTF-8"></script>`,
     ];
     const replaceStyle = [
       /<\/(head|body)>/,

--- a/packages/svrx/scripts/webpack.injector.js
+++ b/packages/svrx/scripts/webpack.injector.js
@@ -10,7 +10,7 @@ const config = {
     filename: 'client.js',
     library: '__svrx__',
     path: path.join(INJECTOR_PATH, 'dist'),
-    libraryTarget: 'umd',
+    libraryTarget: 'window',
   },
   externals: { __svrx__: '__svrx__' },
   mode: 'production',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines         
- [ ] Tests is needed? <!--- Uncheck if not -->
    - [ ] Tests for the changes have been added
- [ ] Docs is needed? <!--- Uncheck if not -->
    - [ ] Docs have been added / updated               

## What kind of change does this PR introduce? 

- [x] Bug fix
- [ ] Feature
- [ ] Enhencement
- [ ] Refactor
- [ ] Documents
- [ ] Others

<!--- Summarize the changes below  -->

1. Change webpack config `libraryTarget` of the injected svrx client script from `umd` to `window`, 'cause we only loaded through a `<script>` tag

## What is the related issue? 
<!--- Use `#issue_id` to relate an open issue -->

#166 

## Does this PR introduce a breaking change?

- [ ] breaking change？

<!--- If true, describe the breaking change below  -->

## Other information:
