### PR TITLE
Fix enable dashed plugins through cli shortcut

### DIFF
--- a/packages/svrx/__tests__/spec/configure/cli.js
+++ b/packages/svrx/__tests__/spec/configure/cli.js
@@ -282,5 +282,23 @@ describe('CLI Config', () => {
       expect(testPlugin).not.to.be(undefined);
       expect(testPlugin2).not.to.be(undefined);
     });
+
+    it('should parse dashed plugin correctly', () => {
+      // svrx --hello-world
+      const server = createServer({}, {
+        'hello-world': true,
+        helloWorld: true,
+        'dash-plugin': false,
+        dashPlugin: false,
+      });
+      const dash = server.config.getPlugin('hello-world');
+      const camel = server.config.getPlugin('helloWorld');
+      const dashFalse = server.config.getPlugin('dash-plugin');
+      const camelFalse = server.config.getPlugin('dashPlugin');
+      expect(dash).not.to.be(undefined);
+      expect(camel).to.be(undefined);
+      expect(dashFalse).to.be(undefined);
+      expect(camelFalse).to.be(camelFalse);
+    });
   });
 });

--- a/packages/svrx/lib/configure/index.js
+++ b/packages/svrx/lib/configure/index.js
@@ -311,7 +311,10 @@ class Configure {
 
     _.keys(cliPlugins).forEach((name) => {
       const value = cliPlugins[name];
-      const newValue = { name };
+      const newValue = {
+        // helloWorld -> hello-world
+        name: name.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`),
+      };
 
       if (value === false) {
         newValue._enable = false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines         
- [x] Tests is needed? <!--- Uncheck if not -->
    - [x] Tests for the changes have been added
- [ ] Docs is needed? <!--- Uncheck if not -->
    - [ ] Docs have been added / updated               

## What kind of change does this PR introduce? 

- [x] Bug fix
- [ ] Feature
- [ ] Enhencement
- [ ] Refactor
- [ ] Documents
- [ ] Others

<!--- Summarize the changes below  -->

1. fix dashed plugins: `svrx --json-viewer`, cannot find 'svrx-plugin-jsonViewer'

## What is the related issue? 
<!--- Use `#issue_id` to relate an open issue -->



## Does this PR introduce a breaking change?

- [ ] breaking change？

<!--- If true, describe the breaking change below  -->

## Other information:
